### PR TITLE
fix: 修复了某些情况下砍树任务完成后不会切换为默认分身的bug

### DIFF
--- a/src/game/mgr/PlayerAttributeMgr.js
+++ b/src/game/mgr/PlayerAttributeMgr.js
@@ -315,7 +315,7 @@ export default class PlayerAttributeMgr {
             this.initPeachNum = peachNum;
         }
 
-        if (peachNum < global.account.chopTree.stop.num || this.level <= global.account.chopTree.stop.level) {
+        if (peachNum <= global.account.chopTree.stop.num || this.level <= global.account.chopTree.stop.level) {
             logger.warn(`[砍树] 停止任务`);
             this.chopEnabled = false;
 


### PR DESCRIPTION
调试过多次,doChopTree()始终不能进入这个里面
![StormZ0 (21)](https://github.com/user-attachments/assets/c5522d7d-c69f-487b-ad65-fa2929458c9f)
但是设置为小于等于即可
顺便补充一下为什么要这么改
是因为考虑到有的人不会经常修改配置文件内的渡劫等级
实际等级高于设置的渡劫等级
然后配置文件桃子又设置为0
必然就会进入不了这个if